### PR TITLE
WOLF-85: Add support for takari-maven-plugin packaging

### DIFF
--- a/src/main/java/com/redhat/repository/validator/AppConfig.java
+++ b/src/main/java/com/redhat/repository/validator/AppConfig.java
@@ -334,6 +334,7 @@ public class AppConfig {
         DefaultArtifactTypeRegistry registry = new DefaultArtifactTypeRegistry();
         registry.add(new DefaultArtifactType("pom"));
         registry.add(new DefaultArtifactType("maven-plugin", "jar", "", "java"));
+        registry.add(new DefaultArtifactType("takari-maven-plugin", "jar", "", "java"));
         registry.add(new DefaultArtifactType("maven-archetype", "jar", "", "java"));
         registry.add(new DefaultArtifactType("jar", "jar", "", "java"));
         registry.add(new DefaultArtifactType("ejb", "jar", "", "java"));

--- a/src/test/java/com/redhat/repository/validator/impl/TestDependenciesValidator.java
+++ b/src/test/java/com/redhat/repository/validator/impl/TestDependenciesValidator.java
@@ -354,7 +354,22 @@ public class TestDependenciesValidator extends AbstractTest {
         assertLocalRepoContains("com/acme/foo-archetype/1.0/foo-archetype-1.0.pom");
         assertLocalRepoContains("com/acme/foo-archetype/1.0/foo-archetype-1.0.jar");
     }
-    
+
+    @Test // bug WOLF-85
+    public void shouldResolveTakariMavenPluginPackaging() throws IOException {
+        Model fooArchetype = pom().artifactId("foo-takari-maven-plugin").packaging("takari-maven-plugin").create(repoFooDir);
+
+        File fooArchetypeFile = toArtifactFile(repoFooDir, fooArchetype);
+        File fooJarFile = new File(fooArchetypeFile.getParentFile(), "foo-takari-maven-plugin-1.0.jar");
+        Files.move(fooArchetypeFile, fooJarFile);
+
+        validationExecutor.execute(ctx);
+
+        assertSuccess();
+        assertLocalRepoContains("com/acme/foo-takari-maven-plugin/1.0/foo-takari-maven-plugin-1.0.pom");
+        assertLocalRepoContains("com/acme/foo-takari-maven-plugin/1.0/foo-takari-maven-plugin-1.0.jar");
+    }
+
     @Test // bug WOLF-51
     public void shouldNotThrowNPEForUnknownArtifactType() {
         pom().artifactId("foo").packaging("unknown").create(repoFooDir);


### PR DESCRIPTION
Added takari-maven-plugin entry to the ArtifactTypeRegistry because
the DROOLS project uses it for building the kie-maven-plugin.